### PR TITLE
docs: add Chinese README translation and frontend API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,61 @@
-# Modbus Middleware
+# Modbus 中间件
 
-Modbus Middleware is a FastAPI-based service that exposes Modbus RTU/TCP devices to web applications. It provides data polling, SQLite storage, REST and WebSocket APIs, and a mock mode for development.
+Modbus 中间件是一个基于 FastAPI 的服务，用于将 Modbus RTU/TCP 设备暴露给 Web 应用。它提供数据轮询、SQLite 存储、REST 和 WebSocket API 以及用于开发的模拟模式。
 
-## Features
-- Support for Modbus RTU and Modbus TCP
-- SQLite-based persistence
-- Periodic polling of configured registers
-- REST and WebSocket interfaces
-- Mock service for environments without hardware
-- Export history to Excel
+## 功能
+- 支持 Modbus RTU 和 Modbus TCP
+- 基于 SQLite 的持久化
+- 定期轮询配置的寄存器
+- REST 和 WebSocket 接口
+- 在没有硬件的环境下可运行的模拟服务
+- 将历史数据导出为 Excel
 
-## Installation
-1. Clone the repository
+## 安装
+1. 克隆仓库
    ```bash
    git clone https://github.com/ZnBrFlowLab/modbus_middleware.git
    cd modbus_middleware
    ```
-2. Create a virtual environment
+2. 创建虚拟环境
    ```bash
    python3 -m venv venv
    source venv/bin/activate    # Linux/macOS
-   # venv\\Scripts\\activate      # Windows
+   # venv\\Scripts\\activate    # Windows
    ```
-3. Install dependencies
+3. 安装依赖
    ```bash
    pip install -r requirements.txt
    ```
 
-## Usage
+## 使用
 
-### Start the service
+### 启动服务
 ```bash
 uvicorn app:app --host 0.0.0.0 --port 8000
 ```
-Then browse `http://127.0.0.1:8000/docs` for Swagger UI.
+然后访问 `http://127.0.0.1:8000/docs` 查看 Swagger UI。
 
-### Start mock service
+### 前端接口说明
+
+服务默认监听 `8000` 端口，可通过 `--port` 参数修改。以下接口均在该端口暴露（示例以 `http://localhost:8000` 为例）：
+
+| 方法 | 路径 | 说明 | 返回示例 |
+| ---- | ---- | ---- | ---- |
+| GET | `/tags` | 获取所有点位及元信息 | `{ "points": [...] }` |
+| GET | `/values` | 获取当前所有点位值 | `{ "温度_1": 25.3, ... }` |
+| GET | `/values/{name_full}` | 获取指定点位值 | `{ "value": 25.3, "ts": 1710000000 }` |
+| GET | `/history` | 查询历史数据，需传 `name_full`、`since`、`until` 查询参数 | `{ "data": [{"ts":..., "value":...}, ...] }` |
+| POST | `/write` | 写入点位值，Body: `{ "name_full": "...", "value": ... }` | `{ "ok": true }` |
+| WebSocket | `/ws` | 建立 WebSocket 连接获取实时更新 | `{ "type": "update", "data": {"温度_1": 25.3} }` |
+
+前端可通过 `http://<服务器地址>:8000/路径` 发送 HTTP 请求，或使用 `ws://<服务器地址>:8000/ws` 建立 WebSocket 连接。
+
+### 启动模拟服务
 ```bash
 uvicorn app_mock:app --host 0.0.0.0 --port 8000
 ```
 
-### Export readings to Excel
+### 将读数导出为 Excel
 ```bash
 python export_readings_to_excel.py \
     --since "2024-08-01" \
@@ -49,14 +64,14 @@ python export_readings_to_excel.py \
     --filter name2
 ```
 
-## Configuration
-Configuration files live at:
-- `config.yaml` – production settings
-- `config_mock.yaml` – mock settings
+## 配置
+配置文件位于：
+- `config.yaml` – 生产环境设置
+- `config_mock.yaml` – 模拟环境设置
 
-Example snippet:
+示例片段：
 ```yaml
-mode: "rtu"        # running mode: rtu or tcp
+mode: "rtu"        # 运行模式：rtu 或 tcp
 
 rtu:
   port: "/dev/ttyUSB0"
@@ -71,31 +86,31 @@ tcp:
   port: 502
   timeout: 1.0
 
-polling_interval: 5   # seconds
+polling_interval: 5   # 秒
 
 database:
   file: "data.sqlite3"
 ```
 
-## Project Structure
+## 项目结构
 ```
 .
-├── app.py                    # Main service entry
-├── app_mock.py               # Mock service entry
-├── config.yaml               # Real environment configuration
-├── config_mock.yaml          # Mock configuration
-├── export_readings_to_excel.py  # Data export tool
-├── requirements.txt          # Dependency list
-└── README.md                 # Project documentation
+├── app.py                    # 服务入口
+├── app_mock.py               # 模拟服务入口
+├── config.yaml               # 实际环境配置
+├── config_mock.yaml          # 模拟环境配置
+├── export_readings_to_excel.py  # 数据导出工具
+├── requirements.txt          # 依赖列表
+└── README.md                 # 项目文档
 ```
 
-## Contributing
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/xxx`)
-3. Commit your changes (`git commit -am 'Add some xxx'`)
-4. Push the branch (`git push origin feature/xxx`)
-5. Open a Pull Request
+## 贡献
+1. Fork 本仓库
+2. 创建功能分支 (`git checkout -b feature/xxx`)
+3. 提交更改 (`git commit -am 'Add some xxx'`)
+4. 推送分支 (`git push origin feature/xxx`)
+5. 打开 Pull Request
 
-## License
+## 许可证
 MIT
 


### PR DESCRIPTION
## Summary
- translate README to Simplified Chinese for better accessibility
- document frontend-facing REST and WebSocket interfaces with default port and sample responses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4333548708329b02e91446b1434a6